### PR TITLE
relax gemspec rails version from 6 to 5

### DIFF
--- a/full_request_logger.gemspec
+++ b/full_request_logger.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.6.0'
 
-  s.add_dependency 'rails', '>= 6.0.0'
+  s.add_dependency 'rails', '>= 5.0.0'
   s.add_dependency 'redis', '>= 4.0'
 
   s.add_development_dependency 'bundler', '~> 1.17'


### PR DESCRIPTION
I tested it and everything works fine with Rails 5, is there a way to merge this so we can support everyone who haven't updated to 6 yet?