### PR TITLE
Support storing full request logs for jobs

### DIFF
--- a/lib/full_request_logger/engine.rb
+++ b/lib/full_request_logger/engine.rb
@@ -1,5 +1,6 @@
 require "rails/engine"
 require "full_request_logger/middleware"
+require "full_request_logger/job"
 
 module FullRequestLogger
   class Engine < Rails::Engine
@@ -10,6 +11,12 @@ module FullRequestLogger
 
     initializer "full_request_logger.middleware" do
       config.app_middleware.insert_after ::ActionDispatch::RequestId, FullRequestLogger::Middleware
+    end
+
+    initializer "full_request_logger.job" do
+      ActiveSupport.on_load(:active_job) do
+        include FullRequestLogger::Job
+      end
     end
 
     initializer "full_request_logger.configs" do

--- a/lib/full_request_logger/job.rb
+++ b/lib/full_request_logger/job.rb
@@ -1,0 +1,9 @@
+module FullRequestLogger::Job
+  extend ActiveSupport::Concern
+
+  included do
+    alias_method :request_id, :job_id
+
+    after_perform { |job| FullRequestLogger::Processor.new(job).process }
+  end
+end

--- a/lib/full_request_logger/middleware.rb
+++ b/lib/full_request_logger/middleware.rb
@@ -5,7 +5,7 @@ module FullRequestLogger
     end
 
     def call(env)
-      @app.call(env).tap { Processor.new(env).process }
+      @app.call(env).tap { Processor.new(ActionDispatch::Request.new(@env)).process }
     end
   end
 end

--- a/lib/full_request_logger/processor.rb
+++ b/lib/full_request_logger/processor.rb
@@ -1,9 +1,8 @@
 require "full_request_logger/recorder"
-require "action_dispatch/http/request"
 
 class FullRequestLogger::Processor
-  def initialize(env)
-    @env = env
+  def initialize(request)
+    @request = request
   end
 
   def process
@@ -15,6 +14,9 @@ class FullRequestLogger::Processor
   end
 
   private
+    attr_reader :request
+    delegate :request_id, to: :request
+
     def enabled?
       FullRequestLogger.enabled
     end
@@ -31,11 +33,5 @@ class FullRequestLogger::Processor
 
     def recorder
       @recorder ||= FullRequestLogger::Recorder.instance
-    end
-
-    delegate :request_id, to: :request
-
-    def request
-      @request ||= ActionDispatch::Request.new(@env)
     end
 end

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -11,7 +11,7 @@ class ProcessorTest < ActiveSupport::TestCase
   FRL    = FullRequestLogger::Recorder.instance.tap { |frl| frl.attach_to(LOGGER) }
 
   setup do
-    @processor = FullRequestLogger::Processor.new({ "action_dispatch.request_id" => "123" })
+    @processor = FullRequestLogger::Processor.new(ActionDispatch::Request.new({ "action_dispatch.request_id" => "123" }))
   end
 
   teardown { FRL.clear_all }


### PR DESCRIPTION
We've found ourselves on several occasions wanting to have full request logs for jobs processing. That'd be the only way to get the full picture of what's going on with an incoming mail processed in an `ActionMailbox::RoutingJob`, for example.

This pull request tries to do this. With this change we pass a request or job instead of `env` to the processor, and make `ActiveJob` to respond to `request_id` (this is just the `job_id`), so we can use this as Redis key. Then, process and store logs from the job from an `after_perform` callback. This works fine, but not sure if it's the best way to handle it. 

cc @georgeclaghorn @dhh 